### PR TITLE
Add drag-and-drop upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 This is a NextJS starter in Firebase Studio.
 
 To get started, take a look at src/app/page.tsx.
+
+## Novidades
+
+- O campo de upload de arquivos agora aceita drag and drop para facilitar o envio da lista de nomes.


### PR DESCRIPTION
## Summary
- add drag-and-drop support to file upload
- document drag-and-drop feature in README

## Testing
- `npm run typecheck` *(fails: Cannot find module 'react' or its corresponding type declarations)*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_b_685d49252440832196d03aa1807a96a0