### PR TITLE
Add confetti effect for draw results

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,4 @@ To get started, take a look at src/app/page.tsx.
 ## Novidades
 
 - O campo de upload de arquivos agora aceita drag and drop para facilitar o envio da lista de nomes.
+- Agora, ao revelar o nome sorteado, um efeito de confete celebra o resultado.

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@tanstack/react-query": "^5.66.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "canvas-confetti": "^1.9.1",
     "date-fns": "^3.6.0",
     "firebase": "^11.3.0",
     "genkit": "^1.0.4",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -104,6 +104,19 @@ export default function Home() {
     }
   }, [isDrawing, countdown, names]);
 
+  useEffect(() => {
+    if (drawnName) {
+      import("canvas-confetti").then((module) => {
+        const confetti = module.default;
+        confetti({
+          particleCount: 150,
+          spread: 70,
+          origin: { y: 0.6 },
+        });
+      });
+    }
+  }, [drawnName]);
+
   return (
     <div className="flex flex-col items-center justify-start min-h-screen py-24 sm:py-32 px-4 sm:px-6 bg-gradient-to-b from-teal-50 via-white to-teal-100 dark:from-gray-800 dark:via-gray-900 dark:to-gray-800">
       <div className="w-full flex justify-end mb-4">


### PR DESCRIPTION
## Summary
- celebrate the draw result with a confetti animation
- list the new feature in the readme
- add `canvas-confetti` dependency

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_b_685f34ee0c38832193903188131d37d7